### PR TITLE
投稿の人気順並べ替え機能の実装

### DIFF
--- a/app/assets/stylesheets/scss/style.scss
+++ b/app/assets/stylesheets/scss/style.scss
@@ -26,14 +26,28 @@ label {
   color: rgb(51, 102, 221);
 }
 
+.blue-link:hover {
+  color: rgb(13, 74, 216);
+}
+
 .red-link {
   color: rgb(237, 1, 1)
+}
+
+.red-link:hover {
+  color: rgb(198, 0, 0)
 }
 
 .flat-navi {
   display: flex;
   justify-content: space-between;
   gap: 16px;
+}
+
+.form-require {
+  font-size: 12px;
+  color: rgb(237, 1, 1);
+  margin-left: 5px;
 }
 
 .header-container {
@@ -112,6 +126,12 @@ label {
   cursor: pointer;
 }
 
+.blue-button:hover {
+  color: white;
+  text-decoration: none;
+  background-color: rgb(45, 102, 234);
+}
+
 .user-post-container {
   margin: 15px 0;
   padding: 15px 0;
@@ -159,7 +179,7 @@ label {
 
 .sort-navi-button {
   width: 50%;
-  padding: 30px 10px 10px;
+  padding: 20px 10px 10px;
   margin-bottom: 0;
   border-bottom: 1px solid;
 }
@@ -172,7 +192,8 @@ label {
   display: flex;
   align-items: center;
   border-bottom: 1px solid;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
+  padding-bottom: 5px;
 }
 
 .onsen-image-wrapper {
@@ -243,7 +264,12 @@ label {
 
 .onsen-form-input {
   width: 100%;
-  margin-bottom: 4px;
+  padding: 5px;
+}
+
+.onsen-form-input-address {
+  padding: 5px;
+  margin: 5px 0;
 }
 
 .form-link {
@@ -260,5 +286,5 @@ label {
 
 .user-form-input {
   width: 100%;
-  margin-bottom: 4px;
+  padding: 5px;
 }

--- a/app/assets/stylesheets/scss/style.scss
+++ b/app/assets/stylesheets/scss/style.scss
@@ -149,6 +149,25 @@ label {
   margin-right: 20px;
 }
 
+.sort-navi {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  text-align: center;
+  margin-bottom: 5px;
+}
+
+.sort-navi-button {
+  width: 50%;
+  padding: 30px 10px 10px;
+  margin-bottom: 0;
+  border-bottom: 1px solid;
+}
+
+.sort-navi-button:first-of-type {
+  border-right: 0.5px solid;
+}
+
 .onsen {
   display: flex;
   align-items: center;

--- a/app/controllers/onsens_controller.rb
+++ b/app/controllers/onsens_controller.rb
@@ -1,6 +1,10 @@
 class OnsensController < ApplicationController
   def index
-    @onsens = Onsen.order("updated_at DESC")
+    if params[:sort_fav]
+      @onsens = Onsen.includes(:favorited_users).sort {|a,b| b.favorited_users.size <=> a.favorited_users.size}
+    else
+      @onsens = Onsen.order("updated_at DESC")
+    end
   end
 
   def new

--- a/app/models/onsen.rb
+++ b/app/models/onsen.rb
@@ -1,6 +1,7 @@
 class Onsen < ApplicationRecord
   belongs_to :user
   has_many :favorites, dependent: :destroy
+  has_many :favorited_users, through: :favorites, source: :user 
 
   validates :onsen_name, presence: true, length: {maximum: 50}
   validates :onsen_introduction, presence: true, length: {in: 5..300}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,12 +6,12 @@
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="user-form-item">
-        <%= f.label :name %><br>
+        <%= f.label :name %><span aria-hidden="true", class="form-require">※必須</span><br>
         <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "user-form-input" %>
       </div>
 
       <div class="user-form-item">
-        <%= f.label :email %><br>
+        <%= f.label :email %><span aria-hidden="true", class="form-require">※必須</span><br>
         <%= f.email_field :email, autocomplete: "email", class: "user-form-input" %>
       </div>
 
@@ -19,12 +19,12 @@
         <%= f.label :password %>
         <% if @minimum_password_length %>
         <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-        <% end %><br>
+        <% end %><span aria-hidden="true", class="form-require">※必須</span><br>
         <%= f.password_field :password, autocomplete: "new-password", class: "user-form-input" %>
       </div>
 
       <div class="user-form-item">
-        <%= f.label :password_confirmation %><br>
+        <%= f.label :password_confirmation %><span aria-hidden="true", class="form-require">※必須</span><br>
         <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "user-form-input" %>
       </div>
 

--- a/app/views/onsens/index.html.erb
+++ b/app/views/onsens/index.html.erb
@@ -45,6 +45,10 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&libraries=places&callback=initMap" async defer></script>
 </div>
 <div class="onsen-container">
+  <div class="sort-navi" data-turbolinks="false">
+    <h4 class="sort-navi-button"><%= link_to "更新順", "/" %></h4>
+    <h4 class="sort-navi-button"><%= link_to "人気順", onsens_path(sort_fav: "true") %></h4>
+  </div>
   <ul class="onsen-list">
     <% @onsens.each do |onsen| %> 
       <li class="onsen">

--- a/app/views/onsens/new.html.erb
+++ b/app/views/onsens/new.html.erb
@@ -48,19 +48,19 @@
   <div class="form-container">
     <%= form_with model: @onsen, local: true do |f| %>
       <div class="onsen-form-item">
-        <%= f.label :address, "所在地" %>
-        <div class="onsen-form-input">
-          <%= f.text_field :address, placeholder: "温泉所在地を入力", id: :address %>
-          <input type="button" value="検索" onclick="codeAddress()">
+        <%= f.label :address, "所在地" %><span aria-hidden="true", class="form-require">※必須</span>
+        <div>
+          <%= f.text_field :address, placeholder: "温泉所在地を入力", id: :address, class: "onsen-form-input-address" %>
+          <input type="button" value="検索" onclick="codeAddress()" class="onsen-form-input-address">
         </div>
-        <span>マーカーをドラッグ＆ドロップで位置の調整ができます。</span>
+        <span>検索後マーカーをドラッグ＆ドロップで位置の調整ができます。</span>
       </div>
       <div class="onsen-form-item">
-        <%= f.label :onsen_name, "温泉名" %>
+        <%= f.label :onsen_name, "温泉名" %><span aria-hidden="true", class="form-require">※必須</span>
         <%= f.text_field :onsen_name, placeholder: "温泉名を入力", class: "onsen-form-input" %>
       </div>
       <div class="onsen-form-item">
-        <%= f.label :onsen_introduction, "温泉詳細" %>
+        <%= f.label :onsen_introduction, "温泉詳細" %><span aria-hidden="true", class="form-require">※必須</span>
         <%= f.text_area :onsen_introduction, placeholder: "温泉詳細を入力", class: "onsen-form-input" %>
       </div>
       <div class="onsen-form-item">


### PR DESCRIPTION
温泉一覧をいいねが多い順に並べ替える機能を実装。
一覧画面に更新順・人気順に並べ替えるボタンを作成。
フォームの必須項目に赤字マークを追加。
